### PR TITLE
Disable Numba looplift on _extract_pairs to suppress warning

### DIFF
--- a/src/RsWaveform/iqw/load.py
+++ b/src/RsWaveform/iqw/load.py
@@ -66,7 +66,7 @@ class Load(LoadInterface):
         return data
 
     @staticmethod
-    @jit(forceobj=True)
+    @jit(forceobj=True,looplift=False)
     def _extract_pairs(buf: bytes, start: int = 0) -> bytes:
         """Extract data pairs from binary buffer."""
         single_pair = bytearray()


### PR DESCRIPTION
When numba is installed, every time I run a script that imports `RsWaveform` a warning is printed to console:

```
xxx/venv/lib/python3.10/site-packages/RsWaveform/iqw/load.py:68: NumbaWarning: 
Compilation is falling back to object mode WITHOUT looplifting enabled because Function "_extract_pairs" failed type inference due to: Unknown attribute 'extend' of type bytearray(uint8, 1d, C)

File "../../../../venv/lib/python3.10/site-packages/RsWaveform/iqw/load.py", line 75:
    def _extract_pairs(buf: bytes, start: int = 0) -> bytes:
        <source elided>
        for idx in np.arange(start * 4, length, 8):
            single_pair.extend(buf[idx : idx + 4])
            ^

During: typing of get attribute at xxx/venv/lib/python3.10/site-packages/RsWaveform/iqw/load.py (75)

File "../../../../venv/lib/python3.10/site-packages/RsWaveform/iqw/load.py", line 75:
    def _extract_pairs(buf: bytes, start: int = 0) -> bytes:
        <source elided>
        for idx in np.arange(start * 4, length, 8):
            single_pair.extend(buf[idx : idx + 4])
            ^

  @staticmethod
```

Maybe it is possible to somehow help Numba to looplift this function by giving it some information about the `extend` method, but I don't know how.
My proposed solution is to just specifically disabling looplifting on that function. It is not applied anyway due to above error and by disabling it no warning is printed.

Feel free to manually implement this without merging this PR or implementing a different solution