### PR TITLE
Removes white space in front of timestamp

### DIFF
--- a/src/RsWaveform/wv/load.py
+++ b/src/RsWaveform/wv/load.py
@@ -246,7 +246,7 @@ class Load(LoadInterface):
             elif key in ["vector_max", "clock"]:
                 value = float(value)
             elif key == "date":
-                value = datetime.strptime(value, "%Y-%m-%d;%H:%M:%S")
+                value = datetime.strptime(value.strip(), "%Y-%m-%d;%H:%M:%S")
             elif key == "control_length":
                 value = int(value)
             elif re.match(r"marker_list_\d+", key):


### PR DESCRIPTION
Metadata contains date in this format {DATE: 2025-01-02;03:04:05}, which cannot be decoded as "value" still contains the white space between ":" and the actual timestamp.